### PR TITLE
Add gitlab runner service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,17 @@ services:
     networks:
       - hitechnix-network
 
+  gitlab-runner:
+    container_name: gitlab-runner
+    restart: always
+    image: gitlab/gitlab-runner:alpine
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - gitlab
+    networks:
+      - hitechnix-network
+
 networks:
   hitechnix-network:
     driver: bridge


### PR DESCRIPTION
GitLab Runner service for executing one or many jobs and reporting their progress back to the GitLab instance.