### PR TITLE
Add GitLab Runner Service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,17 @@ services:
     networks:
       - hitechnix-network
 
+  gitlab-runner:
+    container_name: gitlab-runner
+    restart: always
+    image: gitlab/gitlab-runner:alpine
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - gitlab
+    networks:
+      - hitechnix-network
+
 networks:
   hitechnix-network:
     driver: bridge


### PR DESCRIPTION
### A runner is an agent in the GitLab Runner application that runs jobs in a GitLab CI/CD pipeline.

You can refer to their documentation here:

- https://docs.gitlab.com/ee/tutorials/create_register_first_runner/